### PR TITLE
Change pipeline behaviors in both notebooks and python files

### DIFF
--- a/Notebooks/data_loading.ipynb
+++ b/Notebooks/data_loading.ipynb
@@ -106,7 +106,7 @@
     "    \n",
     "    if race_dfs:\n",
     "        all_laps = pd.concat(race_dfs, ignore_index=True)\n",
-    "        all_laps.to_csv(path)\n",
+    "        all_laps.to_csv(path, index=False)\n",
     "        print(f\"Finished loading {season} season data.\")\n",
     "    else:\n",
     "        print(f\"No data available for {season} season yet.\")\n",
@@ -150,7 +150,12 @@
     "\n",
     "    all_laps = pd.concat(race_dfs, ignore_index=True)\n",
     "    \n",
-    "    all_laps.to_csv(path, mode='a')\n",
+    "    with open(path, 'a') as csv:\n",
+    "        csv.write(\"\\n\")\n",
+    "        # if there are previous date\n",
+    "        # don't write column headers again\n",
+    "        all_laps.to_csv(path, 'a', header=False)\n",
+    "\n",
     "    print(f\"Finished updating {season} season data.\")\n",
     "    return None    "
    ]

--- a/Notebooks/data_transformation.ipynb
+++ b/Notebooks/data_transformation.ipynb
@@ -618,12 +618,11 @@
     "        if Path.is_file(path):\n",
     "            # if the file already exists, then don't need to write header again\n",
     "            # need to move the cursor onto a new line before appending \n",
-    "            with open(path, 'a') as append:\n",
-    "                append.write(\"\\n\")\n",
-    "                \n",
-    "            df_transform.to_csv(path, mode=\"a\", header=False)\n",
+    "            with open(path, 'a') as csv:\n",
+    "                csv.write(\"\\n\")\n",
+    "                df_transform.to_csv(path, mode=\"a\", header=False)\n",
     "        else:\n",
-    "            df_transform.to_csv(path)\n",
+    "            df_transform.to_csv(path, index=False)\n",
     " "
    ]
   }

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -35,7 +35,7 @@ def load_all_data(season, path):
 
     if race_dfs:
         all_laps = pd.concat(race_dfs, ignore_index=True)
-        all_laps.to_csv(path)
+        all_laps.to_csv(path, index=False)
         print(f"Finished loading {season} season data.")
     else:
         print(f"No data available for {season} season yet.")
@@ -74,7 +74,12 @@ def update_data(season, path):
 
     all_laps = pd.concat(race_dfs, ignore_index=True)
 
-    all_laps.to_csv(path, mode='a')
+    with open(path, 'a') as csv:
+        csv.write("\n")
+        # if there are previous date
+        # don't write column headers again
+        all_laps.to_csv(path, 'a', header=False)
+
     print(f"Finished updating {season} season data.")
     return None
 
@@ -159,7 +164,7 @@ def add_is_slick(season, df_laps):
     if season == 2018:
         slick_names = visual_config["slick_names"]["18"]
     else:
-        slick_names = visual_config["slick_names"]["19_22"]
+        slick_names = visual_config["slick_names"]["19_"]
 
     df_laps["IsSlick"] = df_laps["Compound"].apply(lambda x: x in slick_names)
 
@@ -495,12 +500,11 @@ def main():
             if Path.is_file(path):
                 # if the file already exists, then don't need to write header again
                 # need to move the cursor onto a new line before appending
-                with open(path, 'a') as append:
-                    append.write("\n")
-
-                df_transform.to_csv(path, mode="a", header=False)
+                with open(path, 'a') as csv:
+                    csv.write("\n")
+                    df_transform.to_csv(path, mode="a", header=False)
             else:
-                df_transform.to_csv(path)
+                df_transform.to_csv(path, index=False)
 
     return 0
 


### PR DESCRIPTION
Including row index when writing to csv was not a problem in previous seasons, as all data were written at once.

As race data are incrementally written now, the row indices generated by Pandas dataframe will not be continuous.

2023 and later csvs will not contain the row indices but previous csvs will remain unmodified. This doesn't interfere with any other functionalities.