### PR TITLE
Add lap_numbers argument to driver stats lineplot and scatterplot

### DIFF
--- a/src/visualization.py
+++ b/src/visualization.py
@@ -87,6 +87,12 @@ def load_laps() -> dict[int, pd.DataFrame]:
 df_dict = load_laps()
 
 
+def get_laps(season: int, round: int) -> pd.DataFrame:
+    """Get transformed laps for a race."""
+    df_season = df_dict[season]
+    return df_season[df_season["RoundNumber"] == round]
+
+
 def find_legend_order(labels: Iterable[str]) -> list[int]:
     """Provide the index of a list of compounds sorted from soft to hard.
 


### PR DESCRIPTION
Add an additional argument to allow zooming in to a specific segment of the race.

Also changed the `upper_bound` value when plotting position changes to 100. The old value of 30 is insufficient as exposed by the Qatar grand prix data.