### PR TITLE
Fixed a bug where the readme machine cannot generate sprint graphics

### DIFF
--- a/f1_visualization/readme_machine.py
+++ b/f1_visualization/readme_machine.py
@@ -49,9 +49,10 @@ warnings.filterwarnings("ignore")
 def main(season: int, round_number: int, grand_prix: bool, update_readme: bool):
     """Make the README suite of visualizations."""
     global DOC_VISUALS_PATH
-    session = f.get_session(season, round_number, "R" if grand_prix else "S")
+    session_type = "R" if grand_prix else "S"
+    session = f.get_session(season, round_number, session_type)
     session.load(telemetry=False, weather=False, messages=False)
-    event_name = session.event["EventName"]
+    event_name = f"{session.event["EventName"]} - {session.name}"
 
     dest = ROOT_PATH / "Visualizations" / f"{season}" / f"{event_name}"
 
@@ -90,6 +91,7 @@ def main(season: int, round_number: int, grand_prix: bool, update_readme: bool):
     viz.driver_stats_lineplot(
         season=season,
         event=round_number,
+        session_type=session_type,
         drivers=podium_finishers,
         y=f"GapTo{race_winner}",
         grid="both",
@@ -97,15 +99,25 @@ def main(season: int, round_number: int, grand_prix: bool, update_readme: bool):
     plt.savefig(dest / "podium_gap.png")
 
     logger.info("Making lap time graph...")
-    viz.driver_stats_scatterplot(season=season, event=round_number, drivers=10)
+    viz.driver_stats_scatterplot(
+        season=season, event=round_number, session_type=session_type, drivers=10
+    )
     plt.savefig(dest / "laptime.png")
 
     logger.info("Making strategy graph...")
-    viz.strategy_barplot(season=season, event=round_number)
+    viz.strategy_barplot(
+        season=season,
+        event=round_number,
+        session_type=session_type,
+    )
     plt.savefig(dest / "strategy.png")
 
     logger.info("Making position change graph...")
-    viz.driver_stats_lineplot(season=season, event=round_number)
+    viz.driver_stats_lineplot(
+        season=season,
+        event=round_number,
+        session_type=session_type,
+    )
     plt.savefig(dest / "position.png")
 
     logger.info("Making teammate comparison boxplot...")
@@ -113,6 +125,7 @@ def main(season: int, round_number: int, grand_prix: bool, update_readme: bool):
     viz.driver_stats_distplot(
         season=season,
         event=round_number,
+        session_type=session_type,
         violin=False,
         swarm=False,
         teammate_comp=True,
@@ -124,6 +137,7 @@ def main(season: int, round_number: int, grand_prix: bool, update_readme: bool):
     viz.driver_stats_distplot(
         season=season,
         event=round_number,
+        session_type=session_type,
         teammate_comp=True,
         drivers=20,
         upper_bound=7,

--- a/f1_visualization/visualization.py
+++ b/f1_visualization/visualization.py
@@ -290,7 +290,7 @@ def get_session_info(
     session = f.get_session(season, event, session_type)
     session.load(laps=False, telemetry=False, weather=False, messages=False)
     round_number = session.event["RoundNumber"]
-    event_name = session.event["EventName"]
+    event_name = f"{session.event["EventName"]} - {session.name}"
 
     if teammate_comp:
         drivers = get_drivers(session, drivers, by="TeamName")


### PR DESCRIPTION
Changed get_session_info behavior. Previously the sprint and race sessions are not properly differentiated

e.g. Both session are named Austrian Grand Prix

New behavior differentiates them by adding the suffix - Race or - Sprint