### PR TITLE
Expect script capture and propagate exit status

### DIFF
--- a/Automation/auto-pull.exp
+++ b/Automation/auto-pull.exp
@@ -22,3 +22,5 @@ expect {
 }
 expect eof
 
+lassign [wait] pid spawn_id os_error_flag exit_status
+exit $exit_status

--- a/Automation/auto-push.exp
+++ b/Automation/auto-push.exp
@@ -21,3 +21,6 @@ expect {
   }
 }
 expect eof
+
+lassign [wait] pid spawn_id os_error_flag exit_status
+exit $exit_status


### PR DESCRIPTION
Fixes #214

Previously, invocations of expect scripts carry exit status 0 as long as the script runs to completion. This is unintended as we want the exit status to align with that of the spawned command. This PR implements this behavior